### PR TITLE
root-*: install fewer packages and use zstd for compression

### DIFF
--- a/dockerfiles/root-builder
+++ b/dockerfiles/root-builder
@@ -2,8 +2,14 @@
 FROM quay.io/lvh-images/lvh AS lvh
 
 FROM debian:sid
-WORKDIR /
-RUN  apt-get update -yq &&  \
-     apt-get upgrade -yq &&  \
-     apt-get install -yq  mmdebstrap libguestfs-tools qemu-utils extlinux
+
 COPY --from=lvh /usr/bin/lvh /usr/bin/lvh
+RUN apt-get update --quiet && \
+     apt-get upgrade --quiet --yes &&  \
+     apt-get install --quiet --yes --no-install-recommends \
+          mmdebstrap \
+          libguestfs-tools \
+          qemu-utils \
+          extlinux \
+          linux-image-amd64 \
+          zstd

--- a/dockerfiles/root-images
+++ b/dockerfiles/root-images
@@ -1,10 +1,12 @@
 # vim: set ft=dockerfile:
 FROM quay.io/lvh-images/root-builder AS builder
 COPY _data /data
-WORKDIR /data
 # mmdebstrap outputs messages in stderr, so we redirect stderr
-RUN lvh images build --dir . 2>&1
+RUN lvh images build --dir /data 2>&1
+RUN zstd --compress --rm --threads=0 /data/images/*.qcow2
 
+# Can't use scratch here because we use `docker create` elsewhere, and
+# that doesn't work without an explicit command. Satisfy this with
+# busybox.
 FROM busybox
-COPY --from=builder /data/images/base.qcow2 /data/images/base.qcow2
-RUN gzip /data/images/base.qcow2
+COPY --from=builder /data/images /data/images


### PR DESCRIPTION
Optimized the root-builder image for fewer
packages to be installed through the use of --no-install-recommends.

Improved the compression (for faster and better ratios) of the generated
qcow2 images by using zstd.

Signed-off-by: Mark Pashmfouroush <mark@isovalent.com>