### PR TITLE
kernel: add CONFIG_MEMCG and CONFIG_CGROUP_PIDS options

### DIFF
--- a/_data/kernels.json
+++ b/_data/kernels.json
@@ -209,6 +209,14 @@
         [
             "--enable",
             "CONFIG_NET_NS"
+        ],
+        [
+            "--enable",
+            "CONFIG_MEMCG"
+        ],
+        [
+            "--enable",
+            "CONFIG_CGROUP_PIDS"
         ]
     ]
 }


### PR DESCRIPTION
These days all machines should have the memory and pids cgroup controllers compiled-in, so add them.

Reference:
- https://elixir.bootlin.com/linux/v4.19/A/ident/CONFIG_MEMCG
- https://elixir.bootlin.com/linux/v4.19/A/ident/CONFIG_CGROUP_PIDS

Closes: #6

Signed-off-by: Djalal Harouni <djalal@isovalent.com>