### PR TITLE
Enable CONFIG_MEMCG_SWAP on 4.19

### DIFF
--- a/_data/kernels.json
+++ b/_data/kernels.json
@@ -60,6 +60,7 @@
         [ "--enable", "CONFIG_LOCALVERSION_AUTO" ],
         [ "--enable", "CONFIG_LWTUNNEL_BPF" ],
         [ "--enable", "CONFIG_MEMCG" ],
+        [ "--enable", "CONFIG_MEMCG_SWAP" ],
         [ "--enable", "CONFIG_NAMESPACES" ],
         [ "--enable", "CONFIG_NET_9P_VIRTIO" ],
         [ "--enable", "CONFIG_NET_9P" ],


### PR DESCRIPTION
It's enabled on 5.* kernels. E.g.,:

    root@kind-5:# grep MEMCG /boot/config-5.15.70
    CONFIG_MEMCG=y
    CONFIG_MEMCG_SWAP=y
    CONFIG_MEMCG_KMEM=y

While on 4.19:

    root@kind-4:~# grep MEMCG /boot/config-4.19.259
    CONFIG_MEMCG=y
    # CONFIG_MEMCG_SWAP is not set
    CONFIG_MEMCG_KMEM=y

Enabling this might help with failures on CI in which kube-apiserver pod gets OOM-killed.

Signed-off-by: Martynas Pumputis <m@lambda.lt>