### PR TITLE
Enable CONFIG_KVM_GUEST

### DIFF
--- a/_data/kernels.json
+++ b/_data/kernels.json
@@ -176,6 +176,8 @@
         [ "--enable", "CONFIG_IP_VS_PROTO_TCP" ],
         [ "--enable", "CONFIG_IP_VS_PROTO_UDP" ],
         [ "--enable", "CONFIG_IP_VS_RR" ],
-        [ "--enable", "CONFIG_SECURITY_APPARMOR" ]
+        [ "--enable", "CONFIG_SECURITY_APPARMOR" ],
+
+        [ "--enable", "CONFIG_KVM_GUEST" ]
     ]
 }


### PR DESCRIPTION
According to https://cateee.net/lkddb/web-lkddb/KVM_GUEST.html, this should enable kvm-clock (and various other optimizations for kvm guests).

Changing the clock source from HPET to kvm-clock should hopefully resolve the slowness of 4.19/5.4 VMs.

Signed-off-by: Martynas Pumputis <m@lambda.lt>