### PR TITLE
Change lvh path

### DIFF
--- a/dockerfiles/kernel-builder
+++ b/dockerfiles/kernel-builder
@@ -3,7 +3,7 @@ FROM quay.io/lvh-images/lvh:latest AS lvh
 
 FROM debian:sid
 
-COPY --from=lvh /ko-app/lvh /usr/bin/lvh
+COPY --from=lvh /usr/bin/lvh /usr/bin/lvh
 RUN  apt-get update -yq &&  \
      apt-get upgrade -yq &&  \
      apt-get install -yq  build-essential git fakeroot xz-utils libssl-dev bc flex libelf-dev bison pahole python3 kmod

--- a/dockerfiles/root-builder
+++ b/dockerfiles/root-builder
@@ -3,7 +3,7 @@ FROM quay.io/lvh-images/lvh:latest AS lvh
 
 FROM debian:sid
 
-COPY --from=lvh /ko-app/lvh /usr/bin/lvh
+COPY --from=lvh /usr/bin/lvh /usr/bin/lvh
 RUN apt-get update --quiet && \
      apt-get upgrade --quiet --yes &&  \
      apt-get install --quiet --yes --no-install-recommends \


### PR DESCRIPTION
We are no longer using "ko", so switch to the old path ("/usr/bin/lvh").

Signed-off-by: Martynas Pumputis <m@lambda.lt>