### PR TITLE
Add images for complexity testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ROOT_IMAGES     ?= $(OCIORG)/root-images
 KERNEL_BUILDER  ?= $(OCIORG)/kernel-builder
 KERNEL_IMAGES	?= $(OCIORG)/kernel-images
 KIND_IMAGES		?= $(OCIORG)/kind
+COMPLEXITY_TEST_IMAGES		?= $(OCIORG)/complexity-test
 
 KERNEL_VERSIONS=4.19 5.4 5.10 5.15 bpf-next
 
@@ -19,6 +20,7 @@ all:
 	@echo "  images:           build root fs images"
 	@echo "  kernels:          build root kernel images"
 	@echo "  kind:             build root kind images"
+	@echo "  complexity-test:  build root complexity-test images"
 
 .PHONY: images_builder
 images_builder:
@@ -42,4 +44,10 @@ kernels: kernels_builder
 kind: kernels images
 	for v in $(KERNEL_VERSIONS) ; do \
 		 $(DOCKER) build --no-cache --build-arg KERNEL_VER=$$v -f dockerfiles/kind-images -t $(KIND_IMAGES):$$v . ; \
+	done
+
+.PHONY: complexity-test
+complexity-test: kernels images
+	for v in $(KERNEL_VERSIONS) ; do \
+		 $(DOCKER) build --no-cache --build-arg KERNEL_VER=$$v -f dockerfiles/complexity-test-images -t $(COMPLEXITY_TEST_IMAGES):$$v . ; \
 	done

--- a/_data/bootstrap/bpf-tools.sh
+++ b/_data/bootstrap/bpf-tools.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -eu
+
+CILIUM_VERSION=v1.12.2
+WORKDIR=/tmp/workspace
+OCI_DIR=cilium-oci
+UNPACKED_DIR=cilium-unpacked
+
+apt-get update
+apt-get -y install skopeo oci-image-tool
+
+mkdir $WORKDIR
+pushd $WORKDIR
+
+#
+# Extract BPF-related tools from Cilium container image. We don't use
+# docker run here because we are running inside the chroot and it's
+# a bit tricky to make it work. So, we simply use skopeo and
+# oci-image-tool here.
+#
+
+# Fetch Cilium container image
+skopeo copy docker://quay.io/cilium/cilium:$CILIUM_VERSION oci:$OCI_DIR
+
+# Unpack Cilium image into local file system
+digest=$(skopeo inspect --format "{{.Digest}}" oci:$OCI_DIR)
+oci-image-tool unpack --ref digest=$digest $OCI_DIR $UNPACKED_DIR
+
+# LLVM/Clang
+mv $UNPACKED_DIR/bin/clang $UNPACKED_DIR/bin/llc /bin
+
+# libbpf
+rm /usr/lib/x86_64-linux-gnu/libbpf* # cleanup pre-installed libbpf
+mv $UNPACKED_DIR/usr/lib/libbpf* /usr/lib/x86_64-linux-gnu
+
+# bpftool
+mv $UNPACKED_DIR/usr/local/bin/bpftool /bin
+
+# iproute2
+rm -f `which ip` # cleanup pre-installed ip
+rm -f `which tc` # cleanip pre-installed tc
+mv $UNPACKED_DIR/usr/local/bin/ip /sbin
+mv $UNPACKED_DIR/usr/local/bin/tc /sbin
+
+# Cleanup
+popd
+rm -rf $WORKDIR
+apt-get -y --purge remove skopeo oci-image-tool
+apt-get clean
+
+# Test
+clang --version
+llc --version
+bpftool version
+ip -V
+tc -V

--- a/_data/images.json
+++ b/_data/images.json
@@ -164,5 +164,82 @@
                 "type": "run-command"
             }
         ]
+    },
+    {
+        "name": "complexity-test.qcow2",
+        "packages": [
+            "ca-certificates",
+            "openssh-server",
+            "sudo",
+            "util-linux",
+            "vim",
+            "libelf1",
+            "libmnl0",
+            "binutils",
+            "make",
+            "golang-1.19",
+            "git",
+            "gcc"
+        ],
+        "actions": [
+            {
+                "comment": "disable password for root",
+                "op": {
+                    "Cmd": "passwd -d root"
+                },
+                "type": "run-command"
+            },
+            {
+                "op": {
+                    "File": "/etc/systemd/system.conf",
+                    "Line": "DefaultLimitNOFILE=65535"
+                },
+                "type": "append-line"
+            },
+            {
+                "comment": "env",
+                "op": {
+                    "File": "/root/.bashrc",
+                    "Line": "export PATH=/root/go/bin:/usr/lib/go-1.19/bin:$PATH"
+                },
+                "type": "append-line"
+            },
+            {
+                "comment": "copy-in bootstrap dir",
+                "op": {
+                    "LocalPath": "/data/bootstrap",
+                    "RemoteDir": "/"
+                },
+                "type": "copy-in"
+            },
+            {
+                "comment": "enable networking",
+                "op": {
+                    "Cmd": "/bootstrap/networkd.sh"
+                },
+                "type": "run-command"
+            },
+            {
+                "comment": "configure sshd",
+                "op": {
+                    "Cmd": "/bootstrap/sshd.sh"
+                },
+                "type": "run-command"
+            },
+            {
+                "comment": "configure mounts",
+                "op": {
+                    "Cmd": "/bootstrap/fstab.sh"
+                },
+                "type": "run-command"
+            },
+            {
+                "comment": "install bpf tools",
+                "op": {
+                    "Cmd": "/bootstrap/bpf-tools.sh"
+                },
+                "type": "run-command"
+            }
+        ]
     }
 ]

--- a/dockerfiles/complexity-test-images
+++ b/dockerfiles/complexity-test-images
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.3-labs
+# vim: set ft=dockerfile:
+
+# override this with --build-arg
+ARG KERNEL_VER=bpf-next
+
+FROM quay.io/lvh-images/root-images:latest AS root-images
+FROM quay.io/lvh-images/kernel-images:"${KERNEL_VER}" AS kimg
+FROM quay.io/lvh-images/root-builder:latest AS builder
+
+ARG KERNEL_VER=bpf-next
+
+WORKDIR /data
+COPY --from=kimg /data/kernels /data/kernels
+COPY --from=root-images /data/images/complexity-test.qcow2.zst /data/images/complexity-test.qcow2.zst
+RUN zstd --decompress --rm --threads=0 /data/images/complexity-test.qcow2.zst
+
+COPY <<EOF /data/images.json
+[
+    {
+        \"name\": \"complexity_test_"${KERNEL_VER}".qcow2\",
+        \"parent\": \"complexity-test.qcow2\",
+        \"actions\": [
+            {
+                \"comment\": \"install "${KERNEL_VER}"\",
+                \"op\": {
+                    \"KernelInstallDir\": \"/data/kernels/"${KERNEL_VER}"\"
+                },
+                \"type\": \"install-kernel\"
+            },
+            { \"op\": { \"Hostname\": \"complexity-test-"${KERNEL_VER}"\"}, \"type\": \"set-hostname\" }
+        ]
+    }
+]
+EOF
+
+# mmdebstrap outputs messages in stderr, so we redirect stderr
+RUN lvh images build --image complexity_test_${KERNEL_VER}.qcow2 --dir /data 2>&1
+RUN zstd --compress --rm --threads=0 /data/images/complexity_test_${KERNEL_VER}.qcow2
+RUN rm /data/images/*.qcow2
+
+FROM busybox
+COPY --from=builder /data/images /data/images


### PR DESCRIPTION
Add new series of images that can be used for testing BPF program's complexity for different kernel versions. The image contains the compilers (clang, llc) and loaders (ip, tc, bpftool) taken from the latest Cilium version, so that we can reproduce the ELF binary similar to the real deployment. We can use it like below.

```
sudo lvh run --host-mount=$PWD --daemonize --image complexity_test_bpf-next.qcow2 -p 10022:22 --qemu-monitor-port 12345

ssh -p 10022 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" root@localhost "make -C /host/bpf"

ssh -p 10022 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" root@localhost "/host/test/bpf/check-complexity.sh"

echo q | nc localhost 12345
```

Example output

```
=> Loading bpf_lxc.c:from-container...
processed 53 insns (limit 1000000) max_states_per_insn 0 total_states 1 peak_states 1 mark_read 1
processed 295 insns (limit 1000000) max_states_per_insn 0 total_states 16 peak_states 16 mark_read 12
processed 563 insns (limit 1000000) max_states_per_insn 0 total_states 30 peak_states 30 mark_read 19
processed 838 insns (limit 1000000) max_states_per_insn 2 total_states 42 peak_states 42 mark_read 16
processed 632 insns (limit 1000000) max_states_per_insn 1 total_states 30 peak_states 30 mark_read 10
processed 3794 insns (limit 1000000) max_states_per_insn 4 total_states 203 peak_states 199 mark_read 14
processed 53338 insns (limit 1000000) max_states_per_insn 11 total_states 2990 peak_states 1296 mark_read 121
processed 3275 insns (limit 1000000) max_states_per_insn 4 total_states 200 peak_states 195 mark_read 24
processed 13246 insns (limit 1000000) max_states_per_insn 8 total_states 744 peak_states 678 mark_read 103
processed 657 insns (limit 1000000) max_states_per_insn 0 total_states 34 peak_states 34 mark_read 11
processed 4426 insns (limit 1000000) max_states_per_insn 6 total_states 316 peak_states 300 mark_read 16
processed 27941 insns (limit 1000000) max_states_per_insn 12 total_states 1752 peak_states 1158 mark_read 120
processed 6289 insns (limit 1000000) max_states_per_insn 7 total_states 390 peak_states 354 mark_read 30
...
```

Signed-off-by: Yutaro Hayakawa <yutaro.hayakawa@isovalent.com>