### PR TITLE
{image,kernel}-builder: use ubuntu image

### DIFF
--- a/dockerfiles/kernel-builder
+++ b/dockerfiles/kernel-builder
@@ -1,7 +1,7 @@
 # vim: set ft=dockerfile:
 FROM quay.io/lvh-images/lvh:latest AS lvh
 
-FROM debian:sid
+FROM ubuntu:rolling
 
 COPY --from=lvh /usr/bin/lvh /usr/bin/lvh
 RUN  apt-get update -yq &&  \

--- a/dockerfiles/root-builder
+++ b/dockerfiles/root-builder
@@ -1,7 +1,7 @@
 # vim: set ft=dockerfile:
 FROM quay.io/lvh-images/lvh:latest AS lvh
 
-FROM debian:sid
+FROM ubuntu:rolling
 
 COPY --from=lvh /usr/bin/lvh /usr/bin/lvh
 RUN apt-get update --quiet && \
@@ -11,5 +11,8 @@ RUN apt-get update --quiet && \
           libguestfs-tools \
           qemu-utils \
           extlinux \
-          linux-image-amd64 \
+          linux-image-generic \
           zstd
+
+RUN apt-get install debian-archive-keyring && \
+    cp /usr/share/keyrings/debian-archive-keyring.gpg /etc/apt/trusted.gpg.d/


### PR DESCRIPTION
Debian sid is, well, Debian sid and we might end up with intermittent failures when trying to instal packages.

For example:

```
 #9 30.30 Reading state information...
 #9 30.36 Some packages could not be installed. This may mean that you have
 #9 30.36 requested an impossible situation or if you are using the unstable
 #9 30.36 distribution that some required packages have not yet been created
 #9 30.36 or been moved out of Incoming.
 #9 30.36 The following information may help to resolve the situation:
```

These will be typically fixed quickly in my experience, but it is still annoying.  Let's switch to use ubuntu:rolling images instead.

For the root-builder, we need to install the debian archive keyring for mmdebstrap to work.

Fixes: https://github.com/cilium/little-vm-helper-images/issues/21