### PR TITLE
_data: add ethtool to kind image

### DIFF
--- a/_data/images.json
+++ b/_data/images.json
@@ -67,7 +67,8 @@
             "build-essential",
             "git",
             "gpg",
-            "libarchive-tools"
+            "libarchive-tools",
+            "ethtool"
         ],
         "actions": [
             {


### PR DESCRIPTION
ethool is required to enable XDP_TX on kind clusters.

Required for #24151.