### PR TITLE
gh/tag-image-releases: remove images

### DIFF
--- a/.github/workflows/tag-images-releases.yaml
+++ b/.github/workflows/tag-images-releases.yaml
@@ -41,5 +41,5 @@ jobs:
               docker pull $src_image
               docker tag $src_image $dst_image
               docker push $dst_image
-              docker image prune -f
+              docker image rmi $src_image $dst_image
           done


### PR DESCRIPTION
docker image prune does not seem to work, and we are still running out of space:

Total reclaimed space: 0B
failed to register layer: ApplyLayer exit status 1 stdout:  stderr: write /data/images/kind.qcow2.zst: no space left on device
Error: Process completed with exit code 1.

Try to remove the imges manually