### PR TITLE
_date/bootstrap: keep the right version of libbpf.so

### DIFF
--- a/_data/bootstrap/bpf-tools.sh
+++ b/_data/bootstrap/bpf-tools.sh
@@ -30,10 +30,6 @@ oci-image-tool unpack --ref digest=$digest $OCI_DIR $UNPACKED_DIR
 # LLVM/Clang
 mv $UNPACKED_DIR/usr/local/bin/clang $UNPACKED_DIR/usr/local/bin/llc /bin
 
-# libbpf
-rm /usr/lib/x86_64-linux-gnu/libbpf* # cleanup pre-installed libbpf
-mv $UNPACKED_DIR/usr/lib/libbpf* /usr/lib/x86_64-linux-gnu
-
 # bpftool
 mv $UNPACKED_DIR/usr/local/bin/bpftool /bin
 


### PR DESCRIPTION
bpf-tools.sh removes libbpf.so.1 and installs libbpf.so.0, however, libbpf.so.0 is not needed by any executables in the image, but libbpf.so.1 is needed by /usr/bin/ip and /usr/sbin/tc. Don't remove the right version and don't install the unneeded one.