### PR TITLE
gh: push version-latest-date-hour docker tag

### DIFF
--- a/.github/workflows/tag-images-releases.yaml
+++ b/.github/workflows/tag-images-releases.yaml
@@ -41,5 +41,13 @@ jobs:
               docker pull $src_image
               docker tag $src_image $dst_image
               docker push $dst_image
+              # Only tag latest image on pushes to main
+              if [[ "$name" == "main" ]]; then
+                  dst_latest_image=$(echo $src_image | sed -e "s/$tag/latest-$tag/")
+                  echo -e "\033[0;32m${src_image} -> ${dst_latest_image}\e[0m";
+                  docker tag $src_image $dst_latest_image
+                  docker push $dst_latest_image
+                  docker image rmi $dst_latest_image
+              fi
               docker image rmi $src_image $dst_image
           done


### PR DESCRIPTION
On pushes to main we want to push a stable version-latest-date-hour tag in order for renovate to ignore tags that were pushed from PRs.