### PR TITLE
renovate: skip image build for renovate PRs updating GitHub actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,7 +43,9 @@
         "patch",
         "pin",
         "pinDigest"
-      ]
+      ],
+      // Don't build images for PRs updating Github actions only
+      "addLabels": "gha-builds/just-dont"
     },
   ],
   "regexManagers": [


### PR DESCRIPTION
Apply the `gha-builds/just-dont` label to renovate PRs updating GitHub actions such that the image build is skipped.