### PR TITLE
Add CentOS 8 stream kernel

### DIFF
--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -57,7 +57,7 @@ jobs:
         name: kernel versions
         with:
           script: |
-              var all_kernels = ['4.19', '5.4', '5.10', '5.15', '6.1', 'bpf-next' ]
+              var all_kernels = ['centos8', '4.19', '5.4', '5.10', '5.15', '6.1', 'bpf-next' ]
               var kernels = []
               const kernel_label_prefix = 'gha-builds/kernel/'
               res = await github.rest.issues.listLabelsOnIssue({

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ COMPLEXITY_TEST_IMAGES    ?= $(OCIORG)/complexity-test
 KERNEL_BUILDER_TAG        ?= main
 ROOT_BUILDER_TAG          ?= main
 ROOT_IMAGES_TAG           ?= main
-KERNEL_VERSIONS           ?= 4.19 5.4 5.10 5.15 6.1 bpf-next
+KERNEL_VERSIONS           ?= centos8 4.19 5.4 5.10 5.15 6.1 bpf-next
 
 DOCKER ?= docker
 export DOCKER_BUILDKIT = 1

--- a/_data/kernels.json
+++ b/_data/kernels.json
@@ -23,6 +23,19 @@
         {
             "name": "4.19",
             "url": "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git?depth=1#linux-4.19.y"
+        },
+        {
+            "name": "centos8",
+            "url": "https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-8.git?depth=1#c8s",
+            "extra_make_args": [
+                "HOSTCC=gcc-10",
+                "CC=gcc-10"
+            ],
+            "opts": [
+                ["--enable", "CONFIG_AMD_MEM_ENCRYPT"],
+                ["--enable", "CONFIG_PREEMPTION"],
+                ["--disable", "CONFIG_RETPOLINE"]
+            ]
         }
     ],
     "common_opts": [

--- a/_data/kernels.json
+++ b/_data/kernels.json
@@ -31,7 +31,10 @@
                 ["--enable", "CONFIG_AMD_MEM_ENCRYPT"],
                 ["--enable", "CONFIG_PREEMPTION"],
                 ["--disable", "CONFIG_RETPOLINE"]
-            ]
+            ],
+	    "extra_make_args": [
+		    "V=1"
+	    ]
         }
     ],
     "common_opts": [

--- a/_data/kernels.json
+++ b/_data/kernels.json
@@ -27,10 +27,6 @@
         {
             "name": "centos8",
             "url": "https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-8.git?depth=1#c8s",
-            "extra_make_args": [
-                "HOSTCC=gcc-10",
-                "CC=gcc-10"
-            ],
             "opts": [
                 ["--enable", "CONFIG_AMD_MEM_ENCRYPT"],
                 ["--enable", "CONFIG_PREEMPTION"],

--- a/dockerfiles/kernel-builder
+++ b/dockerfiles/kernel-builder
@@ -1,4 +1,5 @@
 # vim: set ft=dockerfile:
+# Pull in lvh with https support.
 FROM quay.io/lvh-images/lvh:latest AS lvh
 
 FROM ubuntu:rolling

--- a/dockerfiles/kernel-builder
+++ b/dockerfiles/kernel-builder
@@ -6,6 +6,6 @@ FROM ubuntu:rolling
 COPY --from=lvh /usr/bin/lvh /usr/bin/lvh
 RUN  apt-get update -yq &&  \
      apt-get upgrade -yq &&  \
-     apt-get install -yq  build-essential git fakeroot xz-utils libssl-dev bc flex libelf-dev bison python3 kmod cmake libelf-dev libdwarf-dev libdw-dev
+     apt-get install -yq  build-essential git fakeroot xz-utils libssl-dev bc flex libelf-dev bison python3 kmod cmake libelf-dev libdwarf-dev libdw-dev gcc-10
 RUN git clone --depth=1 --shallow-submodules --recurse-submodules --single-branch https://git.kernel.org/pub/scm/devel/pahole/pahole.git /tmp/pahole
 RUN cd /tmp/pahole && mkdir -p build && cd build && cmake -D__LIB=lib .. && make && make install && ldconfig /usr/local

--- a/dockerfiles/kernel-builder-gcc8
+++ b/dockerfiles/kernel-builder-gcc8
@@ -1,0 +1,12 @@
+# vim: set ft=dockerfile:
+# Pull in lvh with https support.
+FROM quay.io/lvh-images/lvh:latest AS lvh
+
+FROM debian:buster
+
+COPY --from=lvh /usr/bin/lvh /usr/bin/lvh
+RUN  apt-get update -yq &&  \
+     apt-get upgrade -yq &&  \
+     apt-get install -yq  build-essential git fakeroot xz-utils libssl-dev bc flex libelf-dev bison python3 kmod cmake libelf-dev libdwarf-dev libdw-dev
+RUN git clone --depth=1 --shallow-submodules --recurse-submodules --single-branch https://git.kernel.org/pub/scm/devel/pahole/pahole.git /tmp/pahole
+RUN cd /tmp/pahole && mkdir -p build && cd build && cmake -D__LIB=lib .. && make && make install && ldconfig /usr/local


### PR DESCRIPTION
Add the CentOS 8 Stream kernel as a proxy for RHEL 8. We currently say that cilium is compatible with RHEL 8 kernels but don't have a way to test for this.