### PR TITLE
Let renovate update Cilium version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,7 @@
   "gitAuthor": "renovate[bot] <bot@renovateapp.com>",
   "includePaths": [
     ".github/workflows/**",
+    "_data/bootstrap/bpf-tools.sh",
     "_data/bootstrap/golang.sh",
     "_data/bootstrap/kind.sh"
   ],
@@ -51,6 +52,7 @@
   "regexManagers": [
     {
       "fileMatch": [
+        "^_data/bootstrap/bpf-tools\.sh$",
         "^_data/bootstrap/golang\.sh$",
         "^_data/bootstrap/kind\.sh$"
       ],

--- a/_data/bootstrap/bpf-tools.sh
+++ b/_data/bootstrap/bpf-tools.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+# renovate: datasource=github-releases depName=cilium/cilium
 CILIUM_VERSION=v1.13.1
 WORKDIR=/tmp/workspace
 OCI_DIR=cilium-oci


### PR DESCRIPTION
Otherwise we might be installing an ancient version of LLVM which causes e.g.  the ci-datapath-verifier workflow on cilium/cilium to go out of sync wrt. LLVM version.