### PR TITLE
renovate: fix config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,7 +46,9 @@
         "pinDigest"
       ],
       // Don't build images for PRs updating Github actions only
-      "addLabels": "gha-builds/just-dont"
+      "addLabels": [
+      	"gha-builds/just-dont",
+      ],
     },
   ],
   "regexManagers": [


### PR DESCRIPTION
Configuration option packageRules[0].addLabels should be a list.

Fixes: 2578ffca9f61 ("renovate: skip image build for renovate PRs updating GitHub actions")