### PR TITLE
Support for arm64 build in the context of docker build

### DIFF
--- a/_data/images.json
+++ b/_data/images.json
@@ -75,9 +75,17 @@
             "gpg",
             "libarchive-tools",
             "ethtool",
-            "systemd-resolved"
+            "systemd-resolved",
+            "ntpdate"
         ],
         "actions": [
+            {
+                "comment": "update date (needed for libguestfs on arm64 running in Docker)",
+                "op": {
+                    "Cmd": "ntpdate pool.ntp.org"
+                },
+                "type": "run-command"
+            },
             {
                 "comment": "disable password for root",
                 "op": {

--- a/dockerfiles/kind-images
+++ b/dockerfiles/kind-images
@@ -20,6 +20,12 @@ RUN apt-get update --quiet && \
      apt-get install --quiet --yes --no-install-recommends \
           zstd qemu-utils libguestfs-tools linux-image-generic
 
+# this might be counter intuitive but without this package (or one of its
+# subpackage), starting qemu with '-device virtio-net-pci,netdev=usernet' will
+# fail with 'failed to find romfile "efi-virtio.rom"'
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then apt-get install -yq --no-install-recommends qemu-system-x86; fi
+
 COPY --from=kimg /data/kernels /data/kernels
 COPY --from=root-images /data/images/kind.qcow2.zst /data/images/kind.qcow2.zst
 RUN zstd --decompress --rm --threads=0 /data/images/kind.qcow2.zst

--- a/dockerfiles/kind-images
+++ b/dockerfiles/kind-images
@@ -45,7 +45,7 @@ EOF
 
 RUN lvh version
 # mmdebstrap outputs messages in stderr, so we redirect stderr
-RUN lvh images build --image kind_${KERNEL_VER}.qcow2 --dir /data 2>&1
+RUN LIBGUESTFS_BACKEND_SETTINGS=force_tcg lvh images build --image kind_${KERNEL_VER}.qcow2 --dir /data 2>&1
 RUN zstd --compress --rm --threads=0 /data/images/kind_${KERNEL_VER}.qcow2
 RUN rm /data/images/*.qcow2
 

--- a/dockerfiles/kind-images
+++ b/dockerfiles/kind-images
@@ -9,7 +9,7 @@ ARG KERNEL_IMAGE_TAG=bpf-next
 
 FROM quay.io/lvh-images/root-images-ci:"${ROOT_IMAGES_TAG}" AS root-images
 FROM quay.io/lvh-images/kernel-images-ci:"${KERNEL_IMAGE_TAG}" AS kimg
-FROM quay.io/lvh-images/lvh:latest AS lvh
+FROM quay.io/lvh-images/lvh:v0.0.17 AS lvh
 FROM ubuntu:rolling AS builder
 
 ARG KERNEL_VER=bpf-next

--- a/dockerfiles/root-builder
+++ b/dockerfiles/root-builder
@@ -17,5 +17,11 @@ RUN apt-get update --quiet && \
           linux-image-generic \
           zstd
 
+ARG TARGETARCH
+# this might be counter intuitive but without this package (or one of its
+# subpackage), starting qemu with '-device virtio-net-pci,netdev=usernet' will
+# fail with 'failed to find romfile "efi-virtio.rom"'
+RUN if [ "$TARGETARCH" = "arm64" ]; then apt-get install -yq --no-install-recommends qemu-system-x86; fi
+
 RUN apt-get install debian-archive-keyring && \
     cp /usr/share/keyrings/debian-archive-keyring.gpg /etc/apt/trusted.gpg.d/

--- a/dockerfiles/root-builder
+++ b/dockerfiles/root-builder
@@ -13,11 +13,11 @@ RUN apt-get update --quiet && \
           mmdebstrap \
           libguestfs-tools \
           qemu-utils \
-          extlinux \
           linux-image-generic \
           zstd
 
 ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then apt-get install -yq --no-install-recommends extlinux; fi
 # this might be counter intuitive but without this package (or one of its
 # subpackage), starting qemu with '-device virtio-net-pci,netdev=usernet' will
 # fail with 'failed to find romfile "efi-virtio.rom"'

--- a/dockerfiles/root-builder
+++ b/dockerfiles/root-builder
@@ -1,6 +1,6 @@
 # vim: set ft=dockerfile:
 # Update to latest version: 2024-01-30
-FROM quay.io/lvh-images/lvh:latest AS lvh
+FROM quay.io/lvh-images/lvh:v0.0.17 AS lvh
 
 # rebuild: 20240130.185336
 

--- a/dockerfiles/root-images
+++ b/dockerfiles/root-images
@@ -8,7 +8,12 @@ FROM quay.io/lvh-images/root-builder-ci:"${ROOT_BUILDER_TAG}" AS builder
 COPY _data /data
 RUN lvh version
 # mmdebstrap outputs messages in stderr, so we redirect stderr
-RUN lvh images build --dir /data 2>&1
+#
+# You cannot use KVM during docker build anyway (without insecure option), it
+# will fallback to emulation. However on arm64, libguestfs gives --machine
+# gic-version=host to qemu which will fail the fallback so we need to
+# explicitely tell libguestfs to use tcg
+RUN LIBGUESTFS_BACKEND_SETTINGS=force_tcg lvh images build --dir /data 2>&1
 RUN zstd --compress --rm --threads=0 /data/images/*.qcow2
 
 # Can't use scratch here because we use `docker create` elsewhere, and


### PR DESCRIPTION
Even though the previous fix made the build work on arm64, this adapts the whole chain to build the image natively on arm64 inside the docker builder container.