### PR TITLE
tag-images: do not return an error on non arch match

### DIFF
--- a/.github/workflows/tag-images-releases.yaml
+++ b/.github/workflows/tag-images-releases.yaml
@@ -40,8 +40,8 @@ jobs:
           for f in $(find ./versions -type f ! -name README.md -printf "%P\n")
           do
               tag=$(cat ./versions/$f)
-              path_arch=$(echo $f | grep -oE 'arm64|amd64')
-              arch_suffix=$( [ -n "$path_arch" ] && echo "-$path_arch" )
+              path_arch=$(echo $f | grep -oE 'arm64|amd64' || true)
+              arch_suffix=$( [ -n "$path_arch" ] && echo "-$path_arch" || true)
               echo f=$f tag=$tag arch_suffix=$arch_suffix
 
               src_image="quay.io/lvh-images/$(echo $f/$tag | sed -e 's_/arm64__;s_/amd64__' | sed -e 's_/_-ci:_; s_/_-_g')"


### PR DESCRIPTION
gha scripts have set -e by default, so grep or other commands must not return != 0 if we don't want to fail.