### PR TITLE
kind: also push multi-arch main tag

### DIFF
--- a/.github/workflows/tag-images-releases.yaml
+++ b/.github/workflows/tag-images-releases.yaml
@@ -68,7 +68,7 @@ jobs:
               multi_image="$kind_image_name:$f-$multi_tag"
               amd64_image="$multi_image-amd64"
               arm64_image="$multi_image-arm64"
-              docker buildx imagetools create -t $multi_image $amd64_image $arm64_image
+              docker buildx imagetools create -t $kind_image_name:$f-main -t $multi_image $amd64_image $arm64_image
           done
       - name: create multi-arch root-images images
         run: |


### PR DESCRIPTION
Just so that the `main-6.6` or `main-bpf-next` is pointing to the multi-arch image as well.