### PR TITLE
_data/bootstrap: Add sysctl.sh to ensure kernel loads /etc/sysctl.conf

### DIFF
--- a/_data/bootstrap/sysctl.sh
+++ b/_data/bootstrap/sysctl.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+
+sysctl -p


### PR DESCRIPTION
... on boot.