### PR TITLE
Add CONFIG_BPF_JIT_ALWAYS_ON to 4.19 5.4

### DIFF
--- a/_data/kernels.json
+++ b/_data/kernels.json
@@ -64,12 +64,16 @@
             "name": "5.4",
             "url": "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git?depth=1#linux-5.4.y",
             "opts": [
-                 [ "--enable",  "CONFIG_FUSE_FS"]
+                 [ "--enable",  "CONFIG_FUSE_FS"],
+                 [ "--enable",  "CONFIG_BPF_JIT_ALWAYS_ON"]
             ]
         },
         {
             "name": "4.19",
-            "url": "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git?depth=1#linux-4.19.y"
+            "url": "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git?depth=1#linux-4.19.y",
+            "opts": [
+                 [ "--enable",  "CONFIG_BPF_JIT_ALWAYS_ON"]
+            ]
         },
         {
             "name": "rhel8",


### PR DESCRIPTION
We use CONFIG_BPF_JIT_DEFAULT_ON in common options to enable jit by default, but that option is not available in 4.19 and 5.4.