### PR TITLE
update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/buildx-stage.yaml
+++ b/.github/workflows/buildx-stage.yaml
@@ -35,7 +35,7 @@ on:
       runner:
         type: string
         required: false
-        default: 'ubuntu-latest-4cores-16gb'
+        default: 'oracle-vm-4cpu-16gb-x86-64'
 jobs:
   build:
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -158,7 +158,7 @@ jobs:
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
-          - {name: "ubuntu-22.04-arm64", arch: "arm64"}
+          - {name: "oracle-vm-4cpu-16gb-arm64", arch: "arm64"}
     uses: ./.github/workflows/buildx-stage.yaml
     secrets: inherit
     with:
@@ -180,7 +180,7 @@ jobs:
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
-          - {name: "ubuntu-22.04-arm64", arch: "arm64"}
+          - {name: "oracle-vm-4cpu-16gb-arm64", arch: "arm64"}
     uses: ./.github/workflows/buildx-stage.yaml
     secrets: inherit
     with:
@@ -206,11 +206,11 @@ jobs:
         kernel: ${{ fromJSON(needs.conf.outputs.kvers) }}
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
-          - {name: "ubuntu-22.04-arm64", arch: "arm64"}
+          - {name: "oracle-vm-4cpu-16gb-arm64", arch: "arm64"}
         exclude:
-          - runner: {name: "ubuntu-22.04-arm64", arch: "arm64"}
+          - runner: {name: "oracle-vm-4cpu-16gb-arm64", arch: "arm64"}
             kernel: {ver: "rhel8.6"}
-          - runner: {name: "ubuntu-22.04-arm64", arch: "arm64"}
+          - runner: {name: "oracle-vm-4cpu-16gb-arm64", arch: "arm64"}
             kernel: {ver: "rhel8.9"}
     uses: ./.github/workflows/buildx-stage.yaml
     secrets: inherit
@@ -313,7 +313,7 @@ jobs:
       matrix:
         runner:
           - "ubuntu-latest"
-          - "ubuntu-22.04-arm64"
+          - "oracle-vm-4cpu-16gb-arm64"
     runs-on: ${{ matrix.runner }}
     steps:
       - name: install crane


### PR DESCRIPTION
CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. You can also join `#cncf-ci-infra` channel on CNCF Slack.