### PR TITLE
Revert "kernels: Fix ip_tables loading on newer kernels"

### DIFF
--- a/_data/kernels.json
+++ b/_data/kernels.json
@@ -195,7 +195,6 @@
         [ "--enable", "CONFIG_NF_SOCKET_IPV4" ],
         [ "--enable", "CONFIG_NF_SOCKET_IPV6" ],
         [ "--module", "CONFIG_NETFILTER_XT_MATCH_SOCKET" ],
-        [ "--enable", "CONFIG_NETFILTER_XTABLES_LEGACY" ],
 
         [ "--module", "CONFIG_IP_NF_TARGET_REDIRECT" ],
         [ "--module", "CONFIG_NETFILTER_XT_MATCH_COMMENT" ],


### PR DESCRIPTION
This reverts commit fefa607f87fe6f7c3b823b2118cd527e6d6c5a96.

DON'T MERGE, want to run CI to see if image builds when reverting commit (can't make it locally 😅 ).
Issue of interest https://github.com/cilium/cilium/issues/41576#issue-3393081744.