### PR TITLE
Revert "Update dependency cilium/cilium to v1.18.1"

### DIFF
--- a/_data/bootstrap/bpf-tools.sh
+++ b/_data/bootstrap/bpf-tools.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # renovate: datasource=github-releases depName=cilium/cilium
-CILIUM_VERSION=v1.18.2
+CILIUM_VERSION=v1.18.0
 WORKDIR=/tmp/workspace
 OCI_DIR=cilium-oci
 UNPACKED_DIR=cilium-unpacked


### PR DESCRIPTION
This reverts commit 6b35103c7b0d0cc71b36d515c88d69e96e4beb9a.

troubleshooting https://github.com/cilium/cilium/issues/41576